### PR TITLE
Colorization inference evaluation during training

### DIFF
--- a/colorizer/inference.py
+++ b/colorizer/inference.py
@@ -58,11 +58,11 @@ class Pix2PixColorizerPipeline(DiffusionPipeline):
         lightness = (bw_images + 1) * 50
         ab = ab * 110
 
-        images = torch.concat([lightness, ab], dim=1)
-        images = lab_to_rgb(images)
-        images = images.cpu()
+        output = torch.concat([lightness, ab], dim=1)
+        output = lab_to_rgb(output)
+        output = output.cpu()
 
         if not return_dict:
-            return (images,)
+            return (output,)
 
-        return ImagePipelineOutput(images=images)
+        return ImagePipelineOutput(images=output)

--- a/colorizer/inference.py
+++ b/colorizer/inference.py
@@ -16,7 +16,7 @@ class Pix2PixColorizerPipeline(DiffusionPipeline):
         self,
         bw_images: torch.Tensor,
         generator: torch.Generator | list[torch.Generator] | None = None,
-        num_inference_steps: int = 2000,
+        num_inference_steps: int = 1000,
         return_dict: bool = True,
     ) -> ImagePipelineOutput | tuple[torch.Tensor]:
 

--- a/colorizer/trainer.py
+++ b/colorizer/trainer.py
@@ -181,13 +181,14 @@ class Trainer:
         disable_progress_bar: bool = False,
     ) -> None:
 
-        if any([validation_images, validation_steps]) and not all(
-            [validation_images, validation_steps]
-        ):
-            raise TypeError(
-                "Invalid keyword arguments: "
-                "Both validation_images and validation_steps must be set to log images"
-            )
+        # if any([validation_images, validation_steps]) and not all(
+        #     [validation_images, validation_steps]
+        # ):
+        #     raise TypeError(
+        #         "Invalid keyword arguments: "
+        #         "Both validation_images and validation_steps
+        #         # must be set to log images"
+        #     )
 
         self.ema.to(self.accelerator.device)
         progress_bar = tqdm(

--- a/colorizer/trainer.py
+++ b/colorizer/trainer.py
@@ -159,16 +159,14 @@ class Trainer:
         val_steps: int | None = None,
     ) -> None:
 
+        if not all([val_images, val_steps]):
+            return
+
         is_valid_step = (
             self.global_step % val_steps == 0
             or self.global_step == self.max_train_steps
         )
-        if (
-            self.accelerator.is_main_process
-            and val_images is not None
-            and val_steps is not None
-            and is_valid_step
-        ):
+        if self.accelerator.is_main_process and is_valid_step:
             for tracker in self.accelerator.trackers:
                 if tracker.name == "tensorboard":
                     writer = tracker.writer

--- a/colorizer/trainer.py
+++ b/colorizer/trainer.py
@@ -160,7 +160,7 @@ class Trainer:
     ) -> None:
 
         is_valid_step = (
-            self.global_step % self.eval_steps == 0
+            self.global_step % val_steps == 0
             or self.global_step == self.max_train_steps
         )
         if (

--- a/colorizer/trainer.py
+++ b/colorizer/trainer.py
@@ -159,7 +159,7 @@ class Trainer:
         val_steps: int | None = None,
     ) -> None:
 
-        if not all([val_images, val_steps]):
+        if any([val_images is None, val_steps is None]):
             return
 
         is_valid_step = (

--- a/colorizer/trainer.py
+++ b/colorizer/trainer.py
@@ -194,7 +194,7 @@ class Trainer:
 
         self.ema.to(self.accelerator.device)
         progress_bar = tqdm(
-            range(self.global_step, self.max_train_steps),
+            range(0, self.max_train_steps),
             disable=not self.accelerator.is_local_main_process or disable_progress_bar,
         )
         progress_bar.set_description("Steps")

--- a/colorizer/trainer.py
+++ b/colorizer/trainer.py
@@ -170,9 +170,11 @@ class Trainer:
             for tracker in self.accelerator.trackers:
                 if tracker.name == "tensorboard":
                     writer = tracker.writer
-                    pred_images = pipeline(val_images)
+                    pred_images = pipeline(val_images).images
                     grid = make_grid(pred_images, nrow=4, padding=1)
-                    writer.add_images("eval-images", grid, global_step=self.global_step)
+                    writer.add_image(
+                        tag="eval-images", img_tensor=grid, global_step=self.global_step
+                    )
 
     def train(
         self,

--- a/colorizer/utils.py
+++ b/colorizer/utils.py
@@ -1,10 +1,13 @@
 import os
 import random
 
+import numpy as np
 import torch
 from kornia.color.lab import rgb_to_lab
+from PIL import Image
 from torchvision import io
 from torchvision.transforms import v2
+from torchvision.utils import make_grid
 
 
 def rgb_to_zero_centered_normalized_lab(
@@ -63,3 +66,14 @@ def load_validation_images(
     images = [transform(io.read_image(path, mode=mode)) for path in images_paths]
     batch = torch.stack(images)
     return batch
+
+
+def evaluate_model(
+    pred_images: torch.tensor, step: int, nrow: int = 4, save_dir: str | None = None
+) -> np.ndarray:
+    grid = make_grid(pred_images, nrow=nrow, padding=1).permute(1, 2, 0).numpy()
+    if save_dir is not None:
+        image_grid = Image.fromarray((grid.numpy() * 255).astype(np.uint8))
+        os.makedirs(save_dir, exist_ok=True)
+        image_grid.save(os.path.join(save_dir, f"step-{step}.png"))
+    return grid.numpy()


### PR DESCRIPTION
Added colorization inference evaluation during training 

To enable this feature the following arguments can now be used:

```python3
trainer = Trainer(
        ...,
        tracker_experiment_name: str | None = None,  # <---
        tracker_log_directory: str = "logs",  # <---
    )
```

```python3
  def train(
      validation_images: torch.Tensor | None = None,  # <---
      validation_steps: int | None = None,  # <---
      disable_progress_bar: bool = False,
  ) -> None:
```

If one of these params is not a valid value an exception will be thrown to the user.